### PR TITLE
Add react app to CORS whitelist

### DIFF
--- a/project/settings.example.py
+++ b/project/settings.example.py
@@ -58,6 +58,7 @@ MIDDLEWARE = [
 
 CORS_ORIGIN_WHITELIST = (
     '0.0.0.0:8000',
+    'localhost:8000',
 )
 
 ROOT_URLCONF = 'project.urls'


### PR DESCRIPTION
Add react app to CORS whitelist. This allows the react app to consume the service API.