### PR TITLE
Add timespans

### DIFF
--- a/core/models/base.py
+++ b/core/models/base.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 
+from core.utils.date.timespan import timespans
+
 
 class NationChoiceMode:
     RANDOM = 'random'
@@ -14,19 +16,19 @@ class NationChoiceMode:
 
 
 class DeadlineFrequency:
-    TWELVE_HOURS = 'twelve_hours'
-    TWENTY_FOUR_HOURS = 'twenty_four_hours'
-    TWO_DAYS = 'two_days'
-    THREE_DAYS = 'three_days'
-    FIVE_DAYS = 'five_days'
-    SEVEN_DAYS = 'seven_days'
+    TWELVE_HOURS = timespans.TWELVE_HOURS.db_string
+    TWENTY_FOUR_HOURS = timespans.TWENTY_FOUR_HOURS.db_string
+    TWO_DAYS = timespans.TWO_DAYS.db_string
+    THREE_DAYS = timespans.THREE_DAYS.db_string
+    FIVE_DAYS = timespans.FIVE_DAYS.db_string
+    SEVEN_DAYS = timespans.SEVEN_DAYS.db_string
     CHOICES = (
-        (TWELVE_HOURS, '12 hours'),
-        (TWENTY_FOUR_HOURS, '24 hours'),
-        (TWO_DAYS, '2 days'),
-        (THREE_DAYS, '3 days'),
-        (FIVE_DAYS, '5 days'),
-        (SEVEN_DAYS, '7 days'),
+        timespans.TWELVE_HOURS.as_choice,
+        timespans.TWENTY_FOUR_HOURS.as_choice,
+        timespans.TWO_DAYS.as_choice,
+        timespans.THREE_DAYS.as_choice,
+        timespans.FIVE_DAYS.as_choice,
+        timespans.SEVEN_DAYS.as_choice,
     )
 
 

--- a/core/tests/test_utils/test_timespan.py
+++ b/core/tests/test_utils/test_timespan.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from core.utils.date import get_timespan, timespans
+
+
+class TestTimespan(TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_get_timespan(self):
+        pairs = [
+            ('twelve_hours', timespans.TWELVE_HOURS),
+            ('twenty_four_hours', timespans.TWENTY_FOUR_HOURS),
+            ('two_days', timespans.TWO_DAYS),
+            ('three_days', timespans.THREE_DAYS),
+            ('five_days', timespans.FIVE_DAYS),
+            ('seven_days', timespans.SEVEN_DAYS),
+        ]
+        for db_string, cls in pairs:
+            self.assertEqual(get_timespan(db_string), cls)
+
+    def test_get_timespan_invalid(self):
+        with self.assertRaises(ValueError):
+            get_timespan('bad_string')
+
+    def test_timedelta(self):
+        delta = timespans.SEVEN_DAYS.timedelta
+        self.assertTrue(isinstance(delta, timezone.timedelta))
+        self.assertEqual(delta.days, 7)
+
+    def test_as_choice(self):
+        choice = timespans.SEVEN_DAYS.as_choice
+        self.assertEqual(choice, ('seven_days', '7 days'))
+
+    def test_str(self):
+        self.assertEqual(str(timespans.SEVEN_DAYS), '7 days')

--- a/core/utils/date/__init__.py
+++ b/core/utils/date/__init__.py
@@ -1,0 +1,7 @@
+from .timespan import get_timespan, timespans
+
+
+__all__ = [
+    'get_timespan',
+    'timespans',
+]

--- a/core/utils/date/timespan.py
+++ b/core/utils/date/timespan.py
@@ -1,0 +1,112 @@
+from django.utils import timezone
+
+
+__all__ = [
+    'get_timespan',
+    'timespans',
+]
+
+
+class TimeSpan:
+    db_string = None
+    display_string = None
+
+    def __str__(self):
+        return self.display_string
+
+    @property
+    def as_choice(self):
+        return (self.db_string, self.display_string)
+
+    @property
+    def timedelta(self):
+        raise NotImplementedError()
+
+
+class TwelveHours(TimeSpan):
+    db_string = 'twelve_hours'
+    display_string = '12 hours'
+
+    @property
+    def timedelta(self):
+        return timezone.timedelta(hours=12)
+
+
+class TwentyFourHours(TimeSpan):
+    db_string = 'twenty_four_hours'
+    display_string = '24 hours'
+
+    @property
+    def timedelta(self):
+        return timezone.timedelta(days=1)
+
+
+class TwoDays(TimeSpan):
+    db_string = 'two_days'
+    display_string = '2 days'
+
+    @property
+    def timedelta(self):
+        return timezone.timedelta(days=2)
+
+
+class ThreeDays(TimeSpan):
+    db_string = 'three_days'
+    display_string = '3 days'
+
+    @property
+    def timedelta(self):
+        return timezone.timedelta(days=3)
+
+
+class FiveDays(TimeSpan):
+    db_string = 'five_days'
+    display_string = '5 days'
+
+    @property
+    def timedelta(self):
+        return timezone.timedelta(days=5)
+
+
+class SevenDays(TimeSpan):
+    db_string = 'seven_days'
+    display_string = '7 days'
+
+    @property
+    def timedelta(self):
+        return timezone.timedelta(days=7)
+
+
+class TimeSpans:
+    TWELVE_HOURS = TwelveHours()
+    TWENTY_FOUR_HOURS = TwentyFourHours()
+    TWO_DAYS = TwoDays()
+    THREE_DAYS = ThreeDays()
+    FIVE_DAYS = FiveDays()
+    SEVEN_DAYS = SevenDays()
+
+    def as_list(self):
+        return [
+            self.TWELVE_HOURS,
+            self.TWENTY_FOUR_HOURS,
+            self.TWO_DAYS,
+            self.THREE_DAYS,
+            self.FIVE_DAYS,
+            self.SEVEN_DAYS,
+        ]
+
+
+timespans = TimeSpans()
+
+
+def get_timespan(db_string):
+    for timespan in timespans.as_list():
+        if timespan.db_string == db_string:
+            return timespan
+    raise ValueError(
+        '{} is not a recognized timezone. Must be one of the following: {}'
+        .format(
+            db_string,
+            ', '.join([ts.db_string for ts in timespans.as_list()])
+        )
+    )


### PR DESCRIPTION
Adds a new type of class called `TimeSpan` which is pretty simple. It basically
encapsulates the `db_string`, `display_string`, and `timedelta` of a particular
timespan, e.g. twenty-four hours.

- Split utils into package and add timespan
- Use timespans for deadlines in models.base
- Import timespan to utils.date.__init__
- Add tests for timespan
