### PR TITLE
Add custom admin

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
 from django.contrib.admin import AdminSite
-from django.contrib.auth.models import Group, User
 from django_admin_listfilter_dropdown.filters import RelatedDropdownFilter
 
 from core import models

--- a/admin/admin.py
+++ b/admin/admin.py
@@ -1,5 +1,13 @@
 from django.contrib import admin
-from . import models
+from django.contrib.admin import AdminSite
+from django.contrib.auth.models import Group, User
+from django_admin_listfilter_dropdown.filters import RelatedDropdownFilter
+
+from core import models
+
+
+class DiplomacyAdminSite(AdminSite):
+    site_header = 'Diplomacy admin'
 
 
 class ReadOnly:
@@ -55,7 +63,10 @@ class GameAdmin(admin.ModelAdmin):
         'initialized_at',
         'variant',
     )
+    list_display = ('name', 'status')
     inlines = [TurnInline]
+    search_fields = ['name']
+    list_filter = ['status', 'private']
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
@@ -68,12 +79,17 @@ class GameAdmin(admin.ModelAdmin):
 
 class TurnAdmin(ReadOnly, admin.ModelAdmin):
 
+    list_filter = (
+        ('game', RelatedDropdownFilter),
+    )
     inlines = [
         TerritoryStateInline,
         PieceStateInline,
     ]
 
 
-admin.site.register(models.Game, GameAdmin)
-admin.site.register(models.Turn, TurnAdmin)
-admin.site.register(models.Variant, VariantAdmin)
+admin_site = DiplomacyAdminSite(name='admin')
+
+admin_site.register(models.Game, GameAdmin)
+admin_site.register(models.Turn, TurnAdmin)
+admin_site.register(models.Variant, VariantAdmin)

--- a/admin/apps.py
+++ b/admin/apps.py
@@ -1,0 +1,6 @@
+from django.contrib.admin.apps import AdminConfig
+
+
+class DiplomacyAdminConfig(AdminConfig):
+    label = 'admin'
+    default_site = 'admin.admin.DiplomacyAdminSite'

--- a/core/models/turn.py
+++ b/core/models/turn.py
@@ -153,6 +153,7 @@ class Turn(models.Model):
 
     def __str__(self):
         return " ".join([
+            f'[{self.game.name}]',
             self.get_season_display(),
             str(self.year),
             self.get_phase_display(),

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -33,7 +33,8 @@ ALLOWED_HOSTS = [
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
+    'django_admin_listfilter_dropdown',
+    'admin.apps.DiplomacyAdminConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,8 +1,9 @@
-from django.contrib import admin
 from django.urls import include, path
 
+from admin.admin import admin_site
+
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path('admin/', admin_site.urls),
     path('api/v1/', include('service.urls')),
     path('api/v1/auth/', include('accounts.api.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bs4
 Django
 coverage
 dj-database-url
+django-admin-list-filter-dropdown>=1.0.3<2.0
 django-cors-headers
 django-extensions
 django-filter


### PR DESCRIPTION
Adds some more advanced behavior to the admin site. Also makes the admin site
use a subclass of django admin so we can add more customised features like
executing actions through custom views.

**To test** bring up containers and have a look at the admin. It's still not
great but a couple small improvements here

- Move admin to separate app
- Add admin app to installed apps
- Use admin app in project urls
- Add django_admin_listfilter_dropdown to requirements
- Prepend [game_name] to turn __str__ method
