### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ development. Follow the docs to get Docker and Docker Compose installed.
 Run the following commands from the root directory to create local copies of
 configuration files:
 
-* Run `cp project/settings/local.example.py project/settings/local.py
-* Run `cp docker-compose.override.yml.example docker-compose.override.yml`
+* Run `cp project/settings/local.example.py project/settings/local.py`
+* Run `cp docker-compose.override.example.yml docker-compose.override.yml`
 
 ### Bring up local copy
 
@@ -59,7 +59,7 @@ configuration files:
 
 ## Loading fixtures for development
 
-To load the fixtures run `make reset_db && make dev_fixtures && superuser` from the root directory
+To load the fixtures run `make reset_db && make dev_fixtures && make superuser` from the root directory
 (outside container). This resets the database, builds the fixtures in
 `fixtures/dev` and creates a superuser with the following credentials:
 ```

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,13 +1,14 @@
 version: '3.6'
+
 services:
   mailcatcher.smtp:
     ports:
       - '127.0.0.1:1080:1080'
   diplomacy.service:
     volumes:
-      - /path/to/diplomacy:/opt/diplomacy/diplomacy
+      - ./:/opt/diplomacy/diplomacy
     ports:
       - "127.0.0.1:8082:8000"
   diplomacy.worker:
     volumes:
-      - /path/to/diplomacy:/opt/diplomacy/diplomacy
+      - ./:/opt/diplomacy/diplomacy


### PR DESCRIPTION
- Fix a few typos in the readme
- Update `docker-compose.override.example.yml` to make service/worker volumes look at current directory (ie `./`) rather than needing to set an absolute path for these yourself