### PR TITLE
Add instructions for setting up without docker (windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docker-compose.override.yml
 
 # celery beat schedule file
 celerybeat-schedule
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,8 @@ superuser:
 	docker exec -it diplomacy_diplomacy.service_1 \
 		./manage.py shell -c "from django.contrib.auth.models import User; \
 		User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
+
+fixtures_local:
+	python manage.py create_game_fixtures
+	python manage.py shell -c "from django.contrib.auth.models import User; \
+	User.objects.create_superuser('admin', 'admin@example.com', 'admin')"

--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ This project consists of the following main components:
 These instructions will get you started with a copy of the project up on your
 local machine for development and testing purposes.
 
-### Prerequisites
+### Docker set up
 
-We use [Docker][docker] and [Docker Compose][docker-compose] in local
+#### Prerequisites
+
+This set up uses [Docker][docker] and [Docker Compose][docker-compose] for local
 development. Follow the docs to get Docker and Docker Compose installed.
 
-### Configuration
+**Note** the docker set up has only been tested for Unix systems. If you are using Windows, follow the non-docker set up instructions.
+
+#### Configuration
 
 Run the following commands from the root directory to create local copies of
 configuration files:
@@ -49,7 +53,7 @@ configuration files:
 * Run `cp project/settings/local.example.py project/settings/local.py`
 * Run `cp docker-compose.override.example.yml docker-compose.override.yml`
 
-### Bring up local copy
+#### Bring up local copy
 
 * Run `docker-compose up` to bring up the project (You can run detached by
   adding `-d` flag)
@@ -57,7 +61,7 @@ configuration files:
   service container by running `docker exec -it diplomacy_diplomacy.service_1`
   and then running whatever command you like.
 
-## Loading fixtures for development
+#### Loading fixtures for development
 
 To load the fixtures run `make reset_db && make dev_fixtures && make superuser` from the root directory
 (outside container). This resets the database, builds the fixtures in
@@ -67,6 +71,71 @@ Username: admin
 Pw: admin
 ```
 You can sign into the client and the service using these credentials.
+
+### Non-docker set up
+
+**Note** this set up has been tested with Windows
+
+#### Prerequisites 
+
+Ensure that you have installed `virtualenv` and `make`.
+
+#### Virtual environent
+
+Create a virtual environment:
+```
+python -m virtualenv venv
+```
+Activate the virtual environment:
+```
+# Unix
+source venv/bin/activate
+
+# Windows - Note if you are using the terminal in VSCode you can select the
+# python interpreter at the bottom left of the screen (requires Python extension)
+venv\Scripts\activate.bat
+```
+
+Install requirements:
+```
+pip install --user -r requirements.txt -r dev_requirements.txt
+```
+
+#### Configuration
+
+Run the following command from the root directory to create local copies of
+configuration files:
+```
+# Unix
+cp project/settings/local.example.py project/settings/local.py
+
+# Windows
+cp .\project\settings\local.example.py .\project\settings\local.py
+```
+
+Open the `local.py` file and edit uncomment each section labeled "non Docker setup" and comment out the sections labeled "Docker setup"
+
+#### Bring up development server
+
+Run the development server on port 8082. This is what the client expects during deevelopment.
+```
+# Unix
+python ./manage.py runserver localhost:8082
+
+# Windows
+python .\manage.py runserver localhost:8082
+```
+
+#### Loading fixtures for development
+
+To load the fixtures run `make fixtures_local` from the root directory. This builds the fixtures in
+`fixtures/dev` and creates a superuser with the following credentials:
+```
+Username: admin
+Pw: admin
+```
+You can sign into the client and the service using these credentials.
+
 
 ## Running the tests
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can sign into the client and the service using these credentials.
 
 **Note** this set up has been tested with Windows
 
-#### Prerequisites 
+#### Prerequisites
 
 Ensure that you have installed `virtualenv` and `make`.
 

--- a/project/settings/local.example.py
+++ b/project/settings/local.example.py
@@ -9,6 +9,10 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:8000',
 )
 
+EMAIL_HOST = 'mailcatcher.smtp'
+EMAIL_PORT = '1025'
+
+# NOTE Docker setup
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
@@ -20,20 +24,19 @@ DATABASES = {
     },
 }
 
-EMAIL_HOST = 'mailcatcher.smtp'
-EMAIL_PORT = '1025'
-
 # NOTE non Docker setup
 # DATABASES = {
 #     'default': {
 #         'ENGINE': 'django.db.backends.sqlite3',
-#         'NAME': 'mydatabase',
+#         'NAME': 'local_database',
 #     }
 # }
 
+# NOTE Docker setup
 FIXTURE_DIRS = (
     '/code/fixtures',
 )
+
 # NOTE non Docker setup
 # FIXTURE_DIRS = (
 #     'fixtures',


### PR DESCRIPTION
Follow the new steps on a windows machine and see where you get to. I had to follow steps online for installing virtualenv and make for windows. Pretty simple tbh.

Added issue for improving set up here:
https://github.com/johnpooch/diplomacy/issues/166